### PR TITLE
Fix: Fuel sync

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -5,6 +5,7 @@ Config = Config or {}
 -- time_step * revolutions_per_minute * vehicle_fuel_consumption_multiplier * global_fuel_consumption_multiplier
 Config.GlobalFuelConsumptionMultiplier = 4.5 -- GTAV Default: 1.0
 Config.SyncFuelBetweenPlayers = true         -- Sync fuel between players
+Config.FuelSyncTime = 10                     -- Time between syncs in seconds
 
 Config.MoneyType = 'cash'       -- Money type to use for the fuel transactions
 Config.FuelPrice = 5            -- Price of the fuel per litre

--- a/Config.lua
+++ b/Config.lua
@@ -4,6 +4,7 @@ Config = Config or {}
 -- file of the vehicle, in the game or in you addon vehicles. The formula (provided by the game) is: 
 -- time_step * revolutions_per_minute * vehicle_fuel_consumption_multiplier * global_fuel_consumption_multiplier
 Config.GlobalFuelConsumptionMultiplier = 4.5 -- GTAV Default: 1.0
+Config.SyncFuelBetweenPlayers = true         -- Sync fuel between players
 
 Config.MoneyType = 'cash'       -- Money type to use for the fuel transactions
 Config.FuelPrice = 5            -- Price of the fuel per litre
@@ -22,7 +23,7 @@ Config.Blip = {
     Scale = 0.7,
     Display = 4,
     ShortRange = true,
-    Text = 'Gasolinera'
+    Text = 'Gas Station'
 }
 
 -- All known pump models in game (I think)

--- a/client/exports.lua
+++ b/client/exports.lua
@@ -5,20 +5,62 @@ local newExports = function (funcName, func)
     exports(funcName, func)
 end
 
-SetFuel = function (vehicle, fuel)
-    if not DoesEntityExist(vehicle) then return end
-    if not IsEntityAVehicle(vehicle) then return end
+local SetFuel = function (vehicle, fuel)
+    if not DoesEntityExist(vehicle) or not IsEntityAVehicle(vehicle) then return end
     if fuel < 0 then fuel = 0 end
     if fuel > 100 then fuel = 100 end
+
+    NetworkRequestControlOfEntity(vehicle)
     SetVehicleFuelLevel(vehicle, fuel + 0.0)
+    if Config.SyncFuelBetweenPlayers then Entity(vehicle).state:set('qb-fuel', fuel + 0.0, true) end
 end
 
 newExports('SetFuel', SetFuel)
 
-GetFuel = function (vehicle)
-    if not DoesEntityExist(vehicle) then return end
-    if not IsEntityAVehicle(vehicle) then return end
+local GetFuel = function (vehicle)
+    if not DoesEntityExist(vehicle) or not IsEntityAVehicle(vehicle) then return end
+
     return GetVehicleFuelLevel(vehicle)
 end
 
 newExports('GetFuel', GetFuel)
+
+if Config.SyncFuelBetweenPlayers then
+
+    AddStateBagChangeHandler("qb-fuel", nil, function(bagName, _, value)
+        local entity = GetEntityFromStateBagName(bagName)
+        if entity == 0 then return end
+        if not DoesEntityExist(entity) or not IsEntityAVehicle(entity) then return end
+        SetVehicleFuelLevel(entity, value + 0.0)
+    end)
+
+    AddEventHandler("gameEventTriggered", function(event, data)
+        if event ~= "CEventNetworkPlayerEnteredVehicle" then return end
+        local player, vehicle = data[1], data[2]
+        local playerPed = PlayerPedId()
+        if player ~= 128 or GetPedInVehicleSeat(vehicle, -1) ~= playerPed then return end
+
+        while DoesEntityExist(vehicle) and GetPedInVehicleSeat(vehicle, -1) == playerPed do
+            if IsVehicleEngineOn(vehicle) then
+                Entity(vehicle).state:set('qb-fuel', GetVehicleFuelLevel(vehicle) + 0.0, true)
+            end
+            Wait(10000)
+        end
+    end)
+
+    AddEventHandler('onResourceStart', function(resourceName)
+        if resourceName ~= GetCurrentResourceName() then return end
+
+        local playerPed = PlayerPedId()
+        local vehicle = GetVehiclePedIsIn(playerPed, false)
+        if vehicle == 0 or GetPedInVehicleSeat(vehicle, -1) ~= playerPed then return end
+
+        while DoesEntityExist(vehicle) and GetPedInVehicleSeat(vehicle, -1) == playerPed do
+            if IsVehicleEngineOn(vehicle) then
+                local fuel = GetVehicleFuelLevel(vehicle)
+                Entity(vehicle).state:set('qb-fuel', fuel + 0.0, true)
+            end
+            Wait(10000)
+        end
+    end)
+end

--- a/client/exports.lua
+++ b/client/exports.lua
@@ -44,7 +44,7 @@ if Config.SyncFuelBetweenPlayers then
             if IsVehicleEngineOn(vehicle) then
                 Entity(vehicle).state:set('qb-fuel', GetVehicleFuelLevel(vehicle) + 0.0, true)
             end
-            Wait(10000)
+            Wait(Config.FuelSyncTime*1000)
         end
     end)
 
@@ -60,7 +60,7 @@ if Config.SyncFuelBetweenPlayers then
                 local fuel = GetVehicleFuelLevel(vehicle)
                 Entity(vehicle).state:set('qb-fuel', fuel + 0.0, true)
             end
-            Wait(10000)
+            Wait(Config.FuelSyncTime*1000)
         end
     end)
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,10 +1,10 @@
 -- ====================|| VARIABLES || ==================== --
 
-QBCore = exports['qb-core']:GetCoreObject()
-CurrentPump = nil
-CurrentObjects = { nozzle = nil, rope = nil }
-CurrentVehicle = nil
-Blips = {}
+local QBCore = exports['qb-core']:GetCoreObject()
+local CurrentPump = nil
+local CurrentObjects = { nozzle = nil, rope = nil }
+local CurrentVehicle = nil
+local Blips = {}
 
 -- ====================|| FUNCTIONS || ==================== --
 
@@ -42,7 +42,7 @@ local refuelVehicle = function (veh)
     local ped = PlayerPedId()
     ClearPedTasks(ped)
     local canLiter = GetAmmoInPedWeapon(ped, `WEAPON_PETROLCAN`)
-    local vehFuel = math.floor(GetFuel(veh) or 0)
+    local vehFuel = math.floor(exports['qb-fuel']:GetFuel(veh) or 0)
 
     if canLiter == 0 then return QBCore.Functions.Notify(Lang:t('error.no_fuel_can'), 'error') end
     if vehFuel == 100 then return QBCore.Functions.Notify(Lang:t('error.vehicle_full'), 'error') end
@@ -60,7 +60,7 @@ local refuelVehicle = function (veh)
     }, {}, {}, {}, function()
         TriggerServerEvent('qb-fuel:server:setCanFuel', canLiter - liter)
         SetPedAmmo(ped, `WEAPON_PETROLCAN`, canLiter - liter)
-        SetFuel(veh, vehFuel + liter)
+        exports['qb-fuel']:SetFuel(veh, vehFuel + liter)
         QBCore.Functions.Notify(Lang:t('success.refueled'), 'success')
         ClearPedTasks(ped)
     end, function() end)
@@ -97,10 +97,11 @@ local grabFuelFromPump = function(ent)
             Wait(500)
             if RopeGetDistanceBetweenEnds(CurrentObjects.rope) > 8.0 then
                 QBCore.Functions.Notify(Lang:t('error.too_far'), 'error')
-                removeObjects()
                 break
             end
         end
+
+        removeObjects()
     end)
 end
 
@@ -220,7 +221,7 @@ local refillVehicleFuel = function (liter)
         local success = QBCore.Functions.TriggerCallback('qb-fuel:server:refillVehicle', liter)
         if not success then return QBCore.Functions.Notify(Lang:t('error.no_money'), 'error') end
         removeObjects()
-        SetFuel(veh, math.floor(GetFuel(veh) or 0) + liter)
+        exports['qb-fuel']:SetFuel(veh, math.floor(exports['qb-fuel']:GetFuel(veh) or 0) + liter)
         QBCore.Functions.Notify(Lang:t('success.refueled'), 'success')
         ClearPedTasks(ped)
     end, function()
@@ -236,7 +237,7 @@ local showFuelMenu = function ()
     SendNUIMessage({
         action = 'show',
         price = Config.FuelPrice,
-        currentFuel = math.floor(GetFuel(veh) or 0),
+        currentFuel = math.floor(exports['qb-fuel']:GetFuel(veh) or 0),
     })
     SetNuiFocus(true, true)
 end


### PR DESCRIPTION
Currently the fuel is not syncing between players, because GTA does not do it, so I added a statebag with a name that can't possible interfere with other statebags in other resources to sync the fuel level. Also I did a loop whenever a player gets in a vehicle to make so for each 10 seconds (default, can be changed in Config) the fuel leven is synced to nearby players.