### PR TITLE
fix: remove unused variable and trailing whitespaces

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql
+          extra_libs: mysql+qblocales
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/client/exports.lua
+++ b/client/exports.lua
@@ -46,7 +46,7 @@ if Config.SyncFuelBetweenPlayers then
                     Entity(vehicle).state:set('qb-fuel', GetVehicleFuelLevel(vehicle) + 0.0, true)
                 end
                 Wait(Config.FuelSyncTime*1000)
-            end 
+            end
         end)
     end)
 
@@ -64,7 +64,7 @@ if Config.SyncFuelBetweenPlayers then
                     Entity(vehicle).state:set('qb-fuel', fuel + 0.0, true)
                 end
                 Wait(Config.FuelSyncTime*1000)
-            end 
+            end
         end)
     end)
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -176,7 +176,6 @@ local nozzleToVehicle = function (veh)
     local zCoords = diff / divisor
 
     LocalPlayer.state:set('hasNozzle', false, true)
-    local ped = PlayerPedId()
 
     if isBike then
         AttachEntityToEntity(CurrentObjects.nozzle, veh, tankBone, 0.0 + nozzleModifiedPosition.x, -0.2 + nozzleModifiedPosition.y, 0.2 + nozzleModifiedPosition.z, -80.0, 0.0, 0.0, true, true, false, false, 1, true)

--- a/client/main.lua
+++ b/client/main.lua
@@ -18,7 +18,7 @@ end
 
 local removeObjects = function ()
     CurrentPump = nil
-    if CurrentVehicle then 
+    if CurrentVehicle then
         Entity(CurrentVehicle).state:set('nozzleAttached', false, true)
         FreezeEntityPosition(CurrentVehicle, false)
         CurrentVehicle = nil


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the `local nozzleToVehicle` function in `client/main.lua` by removing an unused local variable (`ped`). This cleanup improves code readability and removes redundancy.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
