### PR TITLE
feat: Add automatic removal of nozzle when detached from vehicle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -188,6 +188,14 @@ local nozzleToVehicle = function (veh)
     CurrentVehicle = veh
     FreezeEntityPosition(CurrentObjects.nozzle, true)
     FreezeEntityPosition(CurrentVehicle, true)
+
+    CreateThread((function ()
+        while DoesEntityExist(CurrentObjects.nozzle) and DoesEntityExist(CurrentVehicle) and Entity(veh).state.nozzleAttached do
+            Wait(1000)
+        end
+
+        removeObjects()
+    end))
 end
 
 local refillVehicleFuel = function (liter)


### PR DESCRIPTION
## Description

This pull request introduces a new thread in the `nozzleToVehicle` function to monitor the state of the nozzle and vehicle, ensuring proper cleanup when the nozzle is detached. Below is the key change:

* [`client/main.lua`](diffhunk://#diff-6f0b2f6b34829d0f65728f2508a4f5e2ef0d39d59b554b3ec8613c8feaacf74dR191-R198): Added a thread in the `nozzleToVehicle` function to periodically check if the nozzle and vehicle still exist and if the nozzle remains attached. If any of these conditions fail, the `removeObjects` function is called to clean up.

## Checklist

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
